### PR TITLE
Added support for Azure OpenAI Service in bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Slack bot using OpenAI API.
 - `BOT_TOKEN`: Slack bot token
 - `SLACK_APP_TOKEN`: Slack app token
 - `OPENAI_API_KEY`: OpenAI API key
-- `GPT_MODEL`: GPT model ID (default: `gpt-4`)
+- `GPT_MODEL`: GPT model ID (default: `gpt-4`). If `AZURE_BASE_URL` is set, this is treated as a deployment name.
 - `GPT_TEMPERATURE`: GPT temperature (default: `0.5`)
 - `GPT_MAX_TOKENS`: GPT max tokens (default: `700`)
 - `SYSTEM_MESSAGE`: System message (default: `assistant の名前はフレデリカです`)
+- `AZURE_BASE_URL`: Azure OpenAI Service base URL (ex. `https://foo.openai.azure.com/`)

--- a/main.go
+++ b/main.go
@@ -344,7 +344,16 @@ func main() {
 		socketmode.OptionLog(log.New(os.Stdout, "socketmode: ", log.Lshortfile|log.LstdFlags)),
 	)
 
-	gptClient := gogpt.NewClient(openaiAPIKey)
+	var gptClient *gogpt.Client
+	azureBaseUrl, found := os.LookupEnv("AZURE_BASE_URL")
+	if found {
+		config := gogpt.DefaultAzureConfig(openaiAPIKey, azureBaseUrl)
+		// Treat model as deployment name
+		config.AzureModelMapperFunc = func(model string) string { return model }
+		gptClient = gogpt.NewClientWithConfig(config)
+	} else {
+		gptClient = gogpt.NewClient(openaiAPIKey)
+	}
 
 	authTestResponse, err := slackClient.AuthTest()
 	if err != nil {


### PR DESCRIPTION
- Updated README.md to include `AZURE_BASE_URL` environment variable
- Modified main.go to instantiate gptClient based on the presence of `AZURE_BASE_URL`